### PR TITLE
feat: add `useQueryObserver` hook to track state updates

### DIFF
--- a/composable/index.d.ts
+++ b/composable/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../types/composable';

--- a/dist/cjs/composable/index.cjs
+++ b/dist/cjs/composable/index.cjs
@@ -1,0 +1,9 @@
+
+'use client';
+'use strict';
+
+var useQueryObserver = require('./useQueryObserver.cjs');
+
+
+
+exports.useQueryObserver = useQueryObserver.useQueryObserver;

--- a/dist/cjs/composable/useQueryObserver.cjs
+++ b/dist/cjs/composable/useQueryObserver.cjs
@@ -6,7 +6,7 @@ const useLayoutEffect = typeof window !== 'undefined' ? react.useLayoutEffect : 
 const useQueryObserver = (input, {
   onData,
   onError
-} = {}) => {
+}) => {
   const queryCacheEntry$ = input._.$;
   const [context] = react.useState({});
   useLayoutEffect(() => {

--- a/dist/cjs/composable/useQueryObserver.cjs
+++ b/dist/cjs/composable/useQueryObserver.cjs
@@ -1,0 +1,40 @@
+'use strict';
+
+var react = require('react');
+
+const useLayoutEffect = typeof window !== 'undefined' ? react.useLayoutEffect : react.useEffect;
+const useQueryObserver = (input, {
+  onData,
+  onError
+} = {}) => {
+  const queryCacheEntry$ = input._.$;
+  const [context] = react.useState({});
+  useLayoutEffect(() => {
+    context.d = onData;
+    context.e = onError;
+  }, [context, onData, onError]);
+  useLayoutEffect(() => {
+    const unsubscribeState = () => context.a?.forEach(unsubscribe => unsubscribe());
+    const unsubscribeCacheEntry = queryCacheEntry$.subscribe(([{
+      d: data$,
+      e: error$,
+      p: isPending$
+    }]) => {
+      unsubscribeState();
+      context.a = [
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      data$.subscribe(data => context.d?.(data)), error$.subscribe(error => error && context.e?.(error))];
+
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      if (!isPending$.get()) context.d?.(data$.get());
+      if (error$.get()) context.e?.(error$.get());
+    });
+    return () => {
+      unsubscribeState();
+      unsubscribeCacheEntry();
+    };
+  }, [context, queryCacheEntry$]);
+  return input;
+};
+
+exports.useQueryObserver = useQueryObserver;

--- a/dist/cjs/middleware/eventListener.cjs
+++ b/dist/cjs/middleware/eventListener.cjs
@@ -15,7 +15,7 @@ const eventListener = ({
       onSuccess?.(value, meta);
       break;
     case 'error':
-      value && onError?.(value, meta);
+      if (value) onError?.(value, meta);
       break;
   }
 };

--- a/dist/cjs/middleware/index.cjs
+++ b/dist/cjs/middleware/index.cjs
@@ -3,9 +3,9 @@
 'use strict';
 
 var applyMiddleware = require('./applyMiddleware.cjs');
-var eventListener = require('./eventListener.cjs');
+var queryListener = require('./queryListener.cjs');
 
 
 
 exports.applyMiddleware = applyMiddleware.applyMiddleware;
-exports.eventListener = eventListener.eventListener;
+exports.queryListener = queryListener.queryListener;

--- a/dist/cjs/middleware/queryListener.cjs
+++ b/dist/cjs/middleware/queryListener.cjs
@@ -1,6 +1,6 @@
 'use strict';
 
-const eventListener = ({
+const queryListener = ({
   onSuccess,
   onError
 }) => ({
@@ -20,4 +20,4 @@ const eventListener = ({
   }
 };
 
-exports.eventListener = eventListener;
+exports.queryListener = queryListener;

--- a/dist/cjs/useObservable.cjs
+++ b/dist/cjs/useObservable.cjs
@@ -2,8 +2,6 @@
 
 var reactishState = require('reactish-state');
 
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-
 const useData = input => ({
   ...input,
   /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */

--- a/dist/cjs/useObservable.cjs
+++ b/dist/cjs/useObservable.cjs
@@ -7,16 +7,16 @@ var reactishState = require('reactish-state');
 const useData = input => ({
   ...input,
   /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */
-  data: reactishState.useSnapshot(input._.d),
-  isPending: reactishState.useSnapshot(input._.p)
+  data: reactishState.useSnapshot(input._.s.d),
+  isPending: reactishState.useSnapshot(input._.s.p)
 });
 const useError = input => ({
   ...input,
-  error: reactishState.useSnapshot(input._.e)
+  error: reactishState.useSnapshot(input._.s.e)
 });
 const useIsFetching = input => ({
   ...input,
-  isFetching: reactishState.useSnapshot(input._.f)
+  isFetching: reactishState.useSnapshot(input._.s.f)
 });
 const useObservable = input => useData(useError(useIsFetching(input)));
 

--- a/dist/cjs/useQuery_.cjs
+++ b/dist/cjs/useQuery_.cjs
@@ -104,8 +104,11 @@ const useQuery$ = ({
     if (enabled) refetch(utils.UNDEFINED, true);
   }, [enabled, refetch]);
   return {
-    /** @internal [INTERNAL ONLY – DO NOT USE] Observable query state */
-    _: reactishState.useSnapshot(queryCacheEntry)[0],
+    /** @internal [INTERNAL ONLY – DO NOT USE] */
+    _: {
+      s: reactishState.useSnapshot(queryCacheEntry)[0],
+      $: queryCacheEntry
+    },
     refetch: refetch
   };
 };

--- a/dist/cjs/useQuery_.cjs
+++ b/dist/cjs/useQuery_.cjs
@@ -104,12 +104,12 @@ const useQuery$ = ({
     if (enabled) refetch(utils.UNDEFINED, true);
   }, [enabled, refetch]);
   return {
+    refetch,
     /** @internal [INTERNAL ONLY – DO NOT USE] */
     _: {
       s: reactishState.useSnapshot(queryCacheEntry)[0],
       $: queryCacheEntry
-    },
-    refetch: refetch
+    }
   };
 };
 

--- a/dist/esm/composable/index.mjs
+++ b/dist/esm/composable/index.mjs
@@ -1,0 +1,3 @@
+
+'use client';
+export { useQueryObserver } from './useQueryObserver.mjs';

--- a/dist/esm/composable/useQueryObserver.mjs
+++ b/dist/esm/composable/useQueryObserver.mjs
@@ -4,7 +4,7 @@ const useLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect$1 : useE
 const useQueryObserver = (input, {
   onData,
   onError
-} = {}) => {
+}) => {
   const queryCacheEntry$ = input._.$;
   const [context] = useState({});
   useLayoutEffect(() => {

--- a/dist/esm/composable/useQueryObserver.mjs
+++ b/dist/esm/composable/useQueryObserver.mjs
@@ -1,0 +1,38 @@
+import { useState, useLayoutEffect as useLayoutEffect$1, useEffect } from 'react';
+
+const useLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect$1 : useEffect;
+const useQueryObserver = (input, {
+  onData,
+  onError
+} = {}) => {
+  const queryCacheEntry$ = input._.$;
+  const [context] = useState({});
+  useLayoutEffect(() => {
+    context.d = onData;
+    context.e = onError;
+  }, [context, onData, onError]);
+  useLayoutEffect(() => {
+    const unsubscribeState = () => context.a?.forEach(unsubscribe => unsubscribe());
+    const unsubscribeCacheEntry = queryCacheEntry$.subscribe(([{
+      d: data$,
+      e: error$,
+      p: isPending$
+    }]) => {
+      unsubscribeState();
+      context.a = [
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      data$.subscribe(data => context.d?.(data)), error$.subscribe(error => error && context.e?.(error))];
+
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      if (!isPending$.get()) context.d?.(data$.get());
+      if (error$.get()) context.e?.(error$.get());
+    });
+    return () => {
+      unsubscribeState();
+      unsubscribeCacheEntry();
+    };
+  }, [context, queryCacheEntry$]);
+  return input;
+};
+
+export { useQueryObserver };

--- a/dist/esm/middleware/eventListener.mjs
+++ b/dist/esm/middleware/eventListener.mjs
@@ -13,7 +13,7 @@ const eventListener = ({
       onSuccess?.(value, meta);
       break;
     case 'error':
-      value && onError?.(value, meta);
+      if (value) onError?.(value, meta);
       break;
   }
 };

--- a/dist/esm/middleware/index.mjs
+++ b/dist/esm/middleware/index.mjs
@@ -1,4 +1,4 @@
 
 'use client';
 export { applyMiddleware } from './applyMiddleware.mjs';
-export { eventListener } from './eventListener.mjs';
+export { queryListener } from './queryListener.mjs';

--- a/dist/esm/middleware/queryListener.mjs
+++ b/dist/esm/middleware/queryListener.mjs
@@ -1,4 +1,4 @@
-const eventListener = ({
+const queryListener = ({
   onSuccess,
   onError
 }) => ({
@@ -18,4 +18,4 @@ const eventListener = ({
   }
 };
 
-export { eventListener };
+export { queryListener };

--- a/dist/esm/useObservable.mjs
+++ b/dist/esm/useObservable.mjs
@@ -1,7 +1,5 @@
 import { useSnapshot } from 'reactish-state';
 
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-
 const useData = input => ({
   ...input,
   /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */

--- a/dist/esm/useObservable.mjs
+++ b/dist/esm/useObservable.mjs
@@ -5,16 +5,16 @@ import { useSnapshot } from 'reactish-state';
 const useData = input => ({
   ...input,
   /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */
-  data: useSnapshot(input._.d),
-  isPending: useSnapshot(input._.p)
+  data: useSnapshot(input._.s.d),
+  isPending: useSnapshot(input._.s.p)
 });
 const useError = input => ({
   ...input,
-  error: useSnapshot(input._.e)
+  error: useSnapshot(input._.s.e)
 });
 const useIsFetching = input => ({
   ...input,
-  isFetching: useSnapshot(input._.f)
+  isFetching: useSnapshot(input._.s.f)
 });
 const useObservable = input => useData(useError(useIsFetching(input)));
 

--- a/dist/esm/useQuery_.mjs
+++ b/dist/esm/useQuery_.mjs
@@ -102,12 +102,12 @@ const useQuery$ = ({
     if (enabled) refetch(UNDEFINED, true);
   }, [enabled, refetch]);
   return {
+    refetch,
     /** @internal [INTERNAL ONLY – DO NOT USE] */
     _: {
       s: useSnapshot(queryCacheEntry)[0],
       $: queryCacheEntry
-    },
-    refetch: refetch
+    }
   };
 };
 

--- a/dist/esm/useQuery_.mjs
+++ b/dist/esm/useQuery_.mjs
@@ -102,8 +102,11 @@ const useQuery$ = ({
     if (enabled) refetch(UNDEFINED, true);
   }, [enabled, refetch]);
   return {
-    /** @internal [INTERNAL ONLY – DO NOT USE] Observable query state */
-    _: useSnapshot(queryCacheEntry)[0],
+    /** @internal [INTERNAL ONLY – DO NOT USE] */
+    _: {
+      s: useSnapshot(queryCacheEntry)[0],
+      $: queryCacheEntry
+    },
     refetch: refetch
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reactish-query",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reactish-query",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "reactish-state": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactish-query",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Atomic state-powered, lightweight React query library",
   "author": "Zheng Song",
   "license": "MIT",
@@ -15,13 +15,20 @@
   "sideEffects": false,
   "files": [
     "dist/",
-    "types/"
+    "types/",
+    "composable/",
+    "middleware/"
   ],
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
       "require": "./dist/cjs/index.cjs",
       "default": "./dist/esm/index.mjs"
+    },
+    "./composable": {
+      "types": "./types/composable/index.d.ts",
+      "require": "./dist/cjs/composable/index.cjs",
+      "default": "./dist/esm/composable/index.mjs"
     },
     "./middleware": {
       "types": "./types/middleware/index.d.ts",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -47,6 +47,10 @@ const createBuild = ({ inPath = '', outPath = inPath, inFile = 'index.ts' } = {}
 /**
  * @type {import('rollup').RollupOptions[]}
  */
-const config = [createBuild(), createBuild({ inPath: 'middleware/' })];
+const config = [
+  createBuild(),
+  createBuild({ inPath: 'middleware/' }),
+  createBuild({ inPath: 'composable/' })
+];
 
 export default config;

--- a/src/__tests__/useLazyQuery.test.tsx
+++ b/src/__tests__/useLazyQuery.test.tsx
@@ -1,13 +1,13 @@
 import { screen, render, fireEvent, waitFor } from '@testing-library/react';
 import { createQueryClient, defaultQueryClient, QueryProvider } from '../index';
-import { applyMiddleware, eventListener } from '../middleware';
+import { applyMiddleware, queryListener } from '../middleware';
 import { mockRequest, mockPromise, delayFor } from './fakeRequest';
 import { LazyQuery, LazyQueryData } from './LazyQuery';
 
 const onSuccess = vi.fn();
 const onError = vi.fn();
 const queryClient = createQueryClient({
-  middleware: applyMiddleware([eventListener({ onSuccess, onError })])
+  middleware: applyMiddleware([queryListener({ onSuccess, onError })])
 });
 
 describe('useLazyQuery', () => {

--- a/src/composable/index.ts
+++ b/src/composable/index.ts
@@ -1,0 +1,1 @@
+export * from './useQueryObserver';

--- a/src/composable/useQueryObserver.ts
+++ b/src/composable/useQueryObserver.ts
@@ -1,0 +1,65 @@
+import { useLayoutEffect as _useLayoutEffect, useEffect, useState } from 'react';
+import type { State } from 'reactish-state';
+import type {
+  InputQueryResult,
+  ExtractInputDataType,
+  QueryCacheEntry
+} from '../types-internal';
+
+const useLayoutEffect = typeof window !== 'undefined' ? _useLayoutEffect : useEffect;
+
+const useQueryObserver = <TInput extends InputQueryResult>(
+  input: TInput,
+  {
+    onData,
+    onError
+  }: {
+    onData?: (data: ExtractInputDataType<TInput>) => void;
+    onError?: (error: Error) => void;
+  } = {}
+) => {
+  type Data = ExtractInputDataType<TInput>;
+  const queryCacheEntry$ = input._.$ as State<QueryCacheEntry<Data>>;
+  const [context] = useState<{
+    /** @internal Array of unsubscribe functions for query state */
+    a?: (() => void)[];
+
+    /** @internal Stable reference to the onData handler */
+    d?: (data: Data) => void;
+
+    /** @internal Stable reference to the onError handler */
+    e?: (error: Error) => void;
+  }>({});
+
+  useLayoutEffect(() => {
+    context.d = onData;
+    context.e = onError;
+  }, [context, onData, onError]);
+
+  useLayoutEffect(() => {
+    const unsubscribeState = () => context.a?.forEach((unsubscribe) => unsubscribe());
+    const unsubscribeCacheEntry = queryCacheEntry$.subscribe(
+      ([{ d: data$, e: error$, p: isPending$ }]) => {
+        unsubscribeState();
+
+        context.a = [
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+          data$.subscribe((data) => context.d?.(data!)),
+          error$.subscribe((error) => error && context.e?.(error))
+        ];
+
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+        if (!isPending$.get()) context.d?.(data$.get()!);
+        if (error$.get()) context.e?.(error$.get()!);
+      }
+    );
+    return () => {
+      unsubscribeState();
+      unsubscribeCacheEntry();
+    };
+  }, [context, queryCacheEntry$]);
+
+  return input;
+};
+
+export { useQueryObserver };

--- a/src/composable/useQueryObserver.ts
+++ b/src/composable/useQueryObserver.ts
@@ -16,7 +16,7 @@ const useQueryObserver = <TInput extends InputQueryResult>(
   }: {
     onData?: (data: ExtractInputDataType<TInput>) => void;
     onError?: (error: Error) => void;
-  } = {}
+  }
 ) => {
   type Data = ExtractInputDataType<TInput>;
   const queryCacheEntry$ = input._.$ as State<QueryCacheEntry<Data>>;

--- a/src/middleware/eventListener.ts
+++ b/src/middleware/eventListener.ts
@@ -17,7 +17,7 @@ const eventListener =
         break;
 
       case 'error':
-        value && onError?.(value as unknown as Error, meta);
+        if (value) onError?.(value as unknown as Error, meta);
         break;
     }
   };

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,2 +1,2 @@
 export * from './applyMiddleware';
-export * from './eventListener';
+export * from './queryListener';

--- a/src/middleware/queryListener.ts
+++ b/src/middleware/queryListener.ts
@@ -1,6 +1,6 @@
 import type { QueryStateMiddleware, QueryStateMeta } from '../types';
 
-const eventListener =
+const queryListener =
   ({
     onSuccess,
     onError
@@ -22,4 +22,4 @@ const eventListener =
     }
   };
 
-export { eventListener };
+export { queryListener };

--- a/src/types-internal.ts
+++ b/src/types-internal.ts
@@ -27,9 +27,18 @@ export type QueryCacheEntry<TData> = readonly [CacheEntryState<TData>, CacheEntr
 export type QueryStateCode = keyof CacheEntryState<unknown>;
 
 export interface InternalHookApi<TData> {
-  /** @internal Query state snapshot - safe for rendering */
-  s: CacheEntryState<TData>;
+  /** @internal [INTERNAL ONLY – DO NOT USE] */
+  _: {
+    /** @internal Query state snapshot - safe for rendering */
+    s: CacheEntryState<TData>;
 
-  /** @internal Observable query cache entry - do not render directly */
-  $: State<QueryCacheEntry<TData>>;
+    /** @internal Observable query cache entry - do not render directly */
+    $: State<QueryCacheEntry<TData>>;
+  };
 }
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+export type InputQueryResult = InternalHookApi<any>;
+
+export type ExtractInputDataType<TInput> =
+  TInput extends InternalHookApi<infer TData> ? TData : never;

--- a/src/types-internal.ts
+++ b/src/types-internal.ts
@@ -25,3 +25,11 @@ export interface CacheEntryMeta {
 export type QueryCacheEntry<TData> = readonly [CacheEntryState<TData>, CacheEntryMeta];
 
 export type QueryStateCode = keyof CacheEntryState<unknown>;
+
+export interface InternalHookApi<TData> {
+  /** @internal Query state snapshot - safe for rendering */
+  s: CacheEntryState<TData>;
+
+  /** @internal Observable query cache entry - do not render directly */
+  $: State<QueryCacheEntry<TData>>;
+}

--- a/src/useObservable.ts
+++ b/src/useObservable.ts
@@ -1,35 +1,26 @@
 import { useSnapshot } from 'reactish-state';
 import type { QueryDataState } from './types';
-import type { InternalHookApi } from './types-internal';
+import type { InputQueryResult, ExtractInputDataType } from './types-internal';
 
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-type InputState = { _: InternalHookApi<any> };
-
-type ExtractDataType<TInput> = TInput extends {
-  _: InternalHookApi<infer TData>;
-}
-  ? TData
-  : never;
-
-const useData = <TInput extends InputState>(input: TInput) =>
+const useData = <TInput extends InputQueryResult>(input: TInput) =>
   ({
     ...input,
     /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */
     data: useSnapshot(input._.s.d),
     isPending: useSnapshot(input._.s.p)
-  }) as TInput & QueryDataState<ExtractDataType<TInput>>;
+  }) as TInput & QueryDataState<ExtractInputDataType<TInput>>;
 
-const useError = <TInput extends InputState>(input: TInput) => ({
+const useError = <TInput extends InputQueryResult>(input: TInput) => ({
   ...input,
   error: useSnapshot(input._.s.e)
 });
 
-const useIsFetching = <TInput extends InputState>(input: TInput) => ({
+const useIsFetching = <TInput extends InputQueryResult>(input: TInput) => ({
   ...input,
   isFetching: useSnapshot(input._.s.f)
 });
 
-const useObservable = <TInput extends InputState>(input: TInput) =>
+const useObservable = <TInput extends InputQueryResult>(input: TInput) =>
   useData(useError(useIsFetching(input)));
 
 export { useData, useError, useIsFetching, useObservable };

--- a/src/useObservable.ts
+++ b/src/useObservable.ts
@@ -1,12 +1,12 @@
 import { useSnapshot } from 'reactish-state';
 import type { QueryDataState } from './types';
-import type { CacheEntryState } from './types-internal';
+import type { InternalHookApi } from './types-internal';
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-type InputState = { _: CacheEntryState<any> };
+type InputState = { _: InternalHookApi<any> };
 
 type ExtractDataType<TInput> = TInput extends {
-  _: CacheEntryState<infer TData>;
+  _: InternalHookApi<infer TData>;
 }
   ? TData
   : never;
@@ -15,18 +15,18 @@ const useData = <TInput extends InputState>(input: TInput) =>
   ({
     ...input,
     /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */
-    data: useSnapshot(input._.d),
-    isPending: useSnapshot(input._.p)
+    data: useSnapshot(input._.s.d),
+    isPending: useSnapshot(input._.s.p)
   }) as TInput & QueryDataState<ExtractDataType<TInput>>;
 
 const useError = <TInput extends InputState>(input: TInput) => ({
   ...input,
-  error: useSnapshot(input._.e)
+  error: useSnapshot(input._.s.e)
 });
 
 const useIsFetching = <TInput extends InputState>(input: TInput) => ({
   ...input,
-  isFetching: useSnapshot(input._.f)
+  isFetching: useSnapshot(input._.s.f)
 });
 
 const useObservable = <TInput extends InputState>(input: TInput) =>

--- a/src/useQuery$.ts
+++ b/src/useQuery$.ts
@@ -122,14 +122,13 @@ const useQuery$ = <TData, TKey = unknown>({
   }, [enabled, refetch]);
 
   return {
+    refetch,
     /** @internal [INTERNAL ONLY – DO NOT USE] */
     _: {
       s: useSnapshot(queryCacheEntry)[0],
       $: queryCacheEntry
-    } as InternalHookApi<TData>,
-
-    refetch: refetch as Refetch<TData>
-  };
+    }
+  } as { refetch: Refetch<TData> } & InternalHookApi<TData>;
 };
 
 export { useQuery$ };

--- a/src/useQuery$.ts
+++ b/src/useQuery$.ts
@@ -9,7 +9,7 @@ import type {
   QueryStateMeta,
   QueryHookOptions
 } from './types';
-import type { QueryCacheEntry } from './types-internal';
+import type { QueryCacheEntry, InternalHookApi } from './types-internal';
 import { UNDEFINED, stringify } from './utils';
 import { useQueryContext } from './useQueryContext';
 
@@ -122,8 +122,11 @@ const useQuery$ = <TData, TKey = unknown>({
   }, [enabled, refetch]);
 
   return {
-    /** @internal [INTERNAL ONLY – DO NOT USE] Observable query state */
-    _: useSnapshot(queryCacheEntry)[0],
+    /** @internal [INTERNAL ONLY – DO NOT USE] */
+    _: {
+      s: useSnapshot(queryCacheEntry)[0],
+      $: queryCacheEntry
+    } as InternalHookApi<TData>,
 
     refetch: refetch as Refetch<TData>
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "esModuleInterop": true,
     "moduleResolution": "bundler",
     "target": "esnext",
-    "lib": ["esnext"],
+    "lib": ["esnext", "dom"],
     "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["./src/"]

--- a/types/composable/index.d.ts
+++ b/types/composable/index.d.ts
@@ -1,0 +1,1 @@
+export * from './useQueryObserver';

--- a/types/composable/useQueryObserver.d.ts
+++ b/types/composable/useQueryObserver.d.ts
@@ -1,0 +1,6 @@
+import type { InputQueryResult, ExtractInputDataType } from '../types-internal';
+declare const useQueryObserver: <TInput extends InputQueryResult>(input: TInput, { onData, onError }?: {
+    onData?: (data: ExtractInputDataType<TInput>) => void;
+    onError?: (error: Error) => void;
+}) => TInput;
+export { useQueryObserver };

--- a/types/composable/useQueryObserver.d.ts
+++ b/types/composable/useQueryObserver.d.ts
@@ -1,5 +1,5 @@
 import type { InputQueryResult, ExtractInputDataType } from '../types-internal';
-declare const useQueryObserver: <TInput extends InputQueryResult>(input: TInput, { onData, onError }?: {
+declare const useQueryObserver: <TInput extends InputQueryResult>(input: TInput, { onData, onError }: {
     onData?: (data: ExtractInputDataType<TInput>) => void;
     onError?: (error: Error) => void;
 }) => TInput;

--- a/types/middleware/index.d.ts
+++ b/types/middleware/index.d.ts
@@ -1,2 +1,2 @@
 export * from './applyMiddleware';
-export * from './eventListener';
+export * from './queryListener';

--- a/types/middleware/queryListener.d.ts
+++ b/types/middleware/queryListener.d.ts
@@ -1,6 +1,6 @@
 import type { QueryStateMiddleware, QueryStateMeta } from '../types';
-declare const eventListener: ({ onSuccess, onError }: {
+declare const queryListener: ({ onSuccess, onError }: {
     onSuccess?: (data: unknown, meta: QueryStateMeta) => void;
     onError?: (error: Error, meta: QueryStateMeta) => void;
 }) => QueryStateMiddleware;
-export { eventListener };
+export { queryListener };

--- a/types/types-internal.d.ts
+++ b/types/types-internal.d.ts
@@ -18,8 +18,13 @@ export interface CacheEntryMeta {
 export type QueryCacheEntry<TData> = readonly [CacheEntryState<TData>, CacheEntryMeta];
 export type QueryStateCode = keyof CacheEntryState<unknown>;
 export interface InternalHookApi<TData> {
-    /** @internal Query state snapshot - safe for rendering */
-    s: CacheEntryState<TData>;
-    /** @internal Observable query cache entry - do not render directly */
-    $: State<QueryCacheEntry<TData>>;
+    /** @internal [INTERNAL ONLY – DO NOT USE] */
+    _: {
+        /** @internal Query state snapshot - safe for rendering */
+        s: CacheEntryState<TData>;
+        /** @internal Observable query cache entry - do not render directly */
+        $: State<QueryCacheEntry<TData>>;
+    };
 }
+export type InputQueryResult = InternalHookApi<any>;
+export type ExtractInputDataType<TInput> = TInput extends InternalHookApi<infer TData> ? TData : never;

--- a/types/types-internal.d.ts
+++ b/types/types-internal.d.ts
@@ -17,3 +17,9 @@ export interface CacheEntryMeta {
 }
 export type QueryCacheEntry<TData> = readonly [CacheEntryState<TData>, CacheEntryMeta];
 export type QueryStateCode = keyof CacheEntryState<unknown>;
+export interface InternalHookApi<TData> {
+    /** @internal Query state snapshot - safe for rendering */
+    s: CacheEntryState<TData>;
+    /** @internal Observable query cache entry - do not render directly */
+    $: State<QueryCacheEntry<TData>>;
+}

--- a/types/useLazyQuery$.d.ts
+++ b/types/useLazyQuery$.d.ts
@@ -1,6 +1,6 @@
 import type { QueryTrigger, LazyQueryHookOptions } from './types';
 declare const useLazyQuery$: <TData, TArgs, TKey = unknown>(options: LazyQueryHookOptions<TData, TKey, TArgs>) => {
     trigger: QueryTrigger<TData, TArgs>;
-    _: import("./types-internal").CacheEntryState<TData>;
+    _: import("./types-internal").InternalHookApi<TData>;
 };
 export { useLazyQuery$ };

--- a/types/useLazyQuery$.d.ts
+++ b/types/useLazyQuery$.d.ts
@@ -1,6 +1,9 @@
 import type { QueryTrigger, LazyQueryHookOptions } from './types';
 declare const useLazyQuery$: <TData, TArgs, TKey = unknown>(options: LazyQueryHookOptions<TData, TKey, TArgs>) => {
     trigger: QueryTrigger<TData, TArgs>;
-    _: import("./types-internal").InternalHookApi<TData>;
+    _: {
+        s: import("./types-internal").CacheEntryState<TData>;
+        $: import("reactish-state").State<import("./types-internal").QueryCacheEntry<TData>, unknown>;
+    };
 };
 export { useLazyQuery$ };

--- a/types/useLazyQuery.d.ts
+++ b/types/useLazyQuery.d.ts
@@ -1,7 +1,7 @@
 import type { LazyQueryHookOptions } from './types';
 declare const useLazyQuery: <TData, TArgs, TKey = unknown>(options: LazyQueryHookOptions<TData, TKey, TArgs>) => {
     trigger: import("./types").QueryTrigger<TData, TArgs>;
-    _: import("./types-internal").CacheEntryState<TData>;
+    _: import("./types-internal").InternalHookApi<TData>;
 } & {
     isFetching: boolean;
 } & ({

--- a/types/useLazyQuery.d.ts
+++ b/types/useLazyQuery.d.ts
@@ -1,7 +1,10 @@
 import type { LazyQueryHookOptions } from './types';
 declare const useLazyQuery: <TData, TArgs, TKey = unknown>(options: LazyQueryHookOptions<TData, TKey, TArgs>) => {
     trigger: import("./types").QueryTrigger<TData, TArgs>;
-    _: import("./types-internal").InternalHookApi<TData>;
+    _: {
+        s: import("./types-internal").CacheEntryState<TData>;
+        $: import("reactish-state").State<import("./types-internal").QueryCacheEntry<TData>, unknown>;
+    };
 } & {
     isFetching: boolean;
 } & ({

--- a/types/useMutation.d.ts
+++ b/types/useMutation.d.ts
@@ -1,7 +1,7 @@
 import type { MutationHookOptions } from './types';
 declare const useMutation: <TData, TArgs, TKey = unknown>(options: MutationHookOptions<TData, TKey, TArgs>) => {
     trigger: import("./types").QueryTrigger<TData, TArgs>;
-    _: import("./types-internal").CacheEntryState<TData>;
+    _: import("./types-internal").InternalHookApi<TData>;
 } & ({
     isFetching: boolean;
 } & ({

--- a/types/useMutation.d.ts
+++ b/types/useMutation.d.ts
@@ -1,7 +1,10 @@
 import type { MutationHookOptions } from './types';
 declare const useMutation: <TData, TArgs, TKey = unknown>(options: MutationHookOptions<TData, TKey, TArgs>) => {
     trigger: import("./types").QueryTrigger<TData, TArgs>;
-    _: import("./types-internal").InternalHookApi<TData>;
+    _: {
+        s: import("./types-internal").CacheEntryState<TData>;
+        $: import("reactish-state").State<import("./types-internal").QueryCacheEntry<TData>, unknown>;
+    };
 } & ({
     isFetching: boolean;
 } & ({

--- a/types/useObservable.d.ts
+++ b/types/useObservable.d.ts
@@ -1,23 +1,17 @@
 import type { QueryDataState } from './types';
-import type { InternalHookApi } from './types-internal';
-type InputState = {
-    _: InternalHookApi<any>;
-};
-type ExtractDataType<TInput> = TInput extends {
-    _: InternalHookApi<infer TData>;
-} ? TData : never;
-declare const useData: <TInput extends InputState>(input: TInput) => TInput & QueryDataState<ExtractDataType<TInput>>;
-declare const useError: <TInput extends InputState>(input: TInput) => TInput & {
+import type { InputQueryResult, ExtractInputDataType } from './types-internal';
+declare const useData: <TInput extends InputQueryResult>(input: TInput) => TInput & QueryDataState<ExtractInputDataType<TInput>>;
+declare const useError: <TInput extends InputQueryResult>(input: TInput) => TInput & {
     error: Error | undefined;
 };
-declare const useIsFetching: <TInput extends InputState>(input: TInput) => TInput & {
+declare const useIsFetching: <TInput extends InputQueryResult>(input: TInput) => TInput & {
     isFetching: boolean;
 };
-declare const useObservable: <TInput extends InputState>(input: TInput) => TInput & {
+declare const useObservable: <TInput extends InputQueryResult>(input: TInput) => TInput & {
     isFetching: boolean;
 } & {
     error: Error | undefined;
-} & QueryDataState<ExtractDataType<TInput & {
+} & QueryDataState<ExtractInputDataType<TInput & {
     isFetching: boolean;
 } & {
     error: Error | undefined;

--- a/types/useObservable.d.ts
+++ b/types/useObservable.d.ts
@@ -1,10 +1,10 @@
 import type { QueryDataState } from './types';
-import type { CacheEntryState } from './types-internal';
+import type { InternalHookApi } from './types-internal';
 type InputState = {
-    _: CacheEntryState<any>;
+    _: InternalHookApi<any>;
 };
 type ExtractDataType<TInput> = TInput extends {
-    _: CacheEntryState<infer TData>;
+    _: InternalHookApi<infer TData>;
 } ? TData : never;
 declare const useData: <TInput extends InputState>(input: TInput) => TInput & QueryDataState<ExtractDataType<TInput>>;
 declare const useError: <TInput extends InputState>(input: TInput) => TInput & {

--- a/types/useQuery$.d.ts
+++ b/types/useQuery$.d.ts
@@ -1,7 +1,8 @@
 import type { Refetch, QueryHookOptions } from './types';
+import type { InternalHookApi } from './types-internal';
 declare const useQuery$: <TData, TKey = unknown>({ queryKey, queryFn, enabled, ...options }: QueryHookOptions<TData, TKey>) => {
-    /** @internal [INTERNAL ONLY – DO NOT USE] Observable query state */
-    _: import("./types-internal").CacheEntryState<TData>;
+    /** @internal [INTERNAL ONLY – DO NOT USE] */
+    _: InternalHookApi<TData>;
     refetch: Refetch<TData>;
 };
 export { useQuery$ };

--- a/types/useQuery$.d.ts
+++ b/types/useQuery$.d.ts
@@ -1,8 +1,6 @@
 import type { Refetch, QueryHookOptions } from './types';
 import type { InternalHookApi } from './types-internal';
 declare const useQuery$: <TData, TKey = unknown>({ queryKey, queryFn, enabled, ...options }: QueryHookOptions<TData, TKey>) => {
-    /** @internal [INTERNAL ONLY – DO NOT USE] */
-    _: InternalHookApi<TData>;
     refetch: Refetch<TData>;
-};
+} & InternalHookApi<TData>;
 export { useQuery$ };

--- a/types/useQuery.d.ts
+++ b/types/useQuery.d.ts
@@ -1,6 +1,6 @@
 import type { QueryHookOptions } from './types';
 declare const useQuery: <TData, TKey = unknown>(options: QueryHookOptions<TData, TKey>) => {
-    _: import("./types-internal").CacheEntryState<TData>;
+    _: import("./types-internal").InternalHookApi<TData>;
     refetch: import("./types").Refetch<TData>;
 } & {
     isFetching: boolean;

--- a/types/useQuery.d.ts
+++ b/types/useQuery.d.ts
@@ -1,10 +1,9 @@
 import type { QueryHookOptions } from './types';
 declare const useQuery: <TData, TKey = unknown>(options: QueryHookOptions<TData, TKey>) => {
-    _: import("./types-internal").InternalHookApi<TData>;
     refetch: import("./types").Refetch<TData>;
-} & {
+} & import("./types-internal").InternalHookApi<TData> & ({
     isFetching: boolean;
 } & ({
     error: Error | undefined;
-} & import("./types").QueryDataState<TData>);
+} & import("./types").QueryDataState<TData>));
 export { useQuery };

--- a/types/useQueryData.d.ts
+++ b/types/useQueryData.d.ts
@@ -1,6 +1,5 @@
 import type { QueryHookOptions } from './types';
 declare const useQueryData: <TData, TKey = unknown>(options: QueryHookOptions<TData, TKey>) => {
-    _: import("./types-internal").InternalHookApi<TData>;
     refetch: import("./types").Refetch<TData>;
-} & import("./types").QueryDataState<TData>;
+} & import("./types-internal").InternalHookApi<TData> & import("./types").QueryDataState<TData>;
 export { useQueryData };

--- a/types/useQueryData.d.ts
+++ b/types/useQueryData.d.ts
@@ -1,6 +1,6 @@
 import type { QueryHookOptions } from './types';
 declare const useQueryData: <TData, TKey = unknown>(options: QueryHookOptions<TData, TKey>) => {
-    _: import("./types-internal").CacheEntryState<TData>;
+    _: import("./types-internal").InternalHookApi<TData>;
     refetch: import("./types").Refetch<TData>;
 } & import("./types").QueryDataState<TData>;
 export { useQueryData };


### PR DESCRIPTION
- Add `useQueryObserver` hook to track state updates
- Export `composable` in package
- Rename `eventListener` to `queryListener`